### PR TITLE
Fix URP serialization issue

### DIFF
--- a/source/com.unity.cluster-display.graphics/Editor/Inspectors/ClusterRendererInspector.cs
+++ b/source/com.unity.cluster-display.graphics/Editor/Inspectors/ClusterRendererInspector.cs
@@ -24,7 +24,7 @@ namespace Unity.ClusterDisplay.Graphics.Editor
             using (var check = new EditorGUI.ChangeCheckScope())
             {
 #if CLUSTER_DISPLAY_URP
-                RenderFeatureEditorUtils<ClusterRenderer, UrpPresenter.InjectionPointRenderFeature>.OnInspectorGUI();
+                RenderFeatureEditorUtils<ClusterRenderer, InjectionPointRenderFeature>.OnInspectorGUI();
 #endif
                 CheckForClusterCameraComponents();
                 

--- a/source/com.unity.cluster-display.graphics/Runtime/Camera/InjectionPointRenderFeature.cs
+++ b/source/com.unity.cluster-display.graphics/Runtime/Camera/InjectionPointRenderFeature.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Rendering;
+using UnityEngine.Rendering.Universal;
+
+namespace Unity.ClusterDisplay.Graphics
+{
+    /// <summary>
+    /// A render pass whose purpose is to invoke an event at the desired stage of rendering.
+    /// </summary>
+    class InjectionPointRenderPass : ScriptableRenderPass
+    {
+        public static event Action<ScriptableRenderContext, RenderingData> ExecuteRender = delegate { };
+
+        public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)
+        {
+            ExecuteRender.Invoke(context, renderingData);
+        }
+    }
+
+    /// <summary>
+    /// A render feature whose purpose is to provide an event invoked at a given rendering stage.
+    /// Meant to abstract away the render feature mechanism and allow for simple graphics code injection.
+    /// </summary>
+    public class InjectionPointRenderFeature : ScriptableRendererFeature
+    {
+        InjectionPointRenderPass m_Pass;
+
+        public override void Create()
+        {
+            m_Pass = new InjectionPointRenderPass
+            {
+                renderPassEvent = RenderPassEvent.AfterRendering,
+            };
+        }
+
+        public override void AddRenderPasses(ScriptableRenderer renderer, ref RenderingData renderingData)
+        {
+            renderer.EnqueuePass(m_Pass);
+        }
+    }
+}

--- a/source/com.unity.cluster-display.graphics/Runtime/Camera/InjectionPointRenderFeature.cs.meta
+++ b/source/com.unity.cluster-display.graphics/Runtime/Camera/InjectionPointRenderFeature.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ae01727733165294ebe5c1f1866bca22
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/source/com.unity.cluster-display.graphics/Runtime/Camera/UrpPresenter.cs
+++ b/source/com.unity.cluster-display.graphics/Runtime/Camera/UrpPresenter.cs
@@ -8,41 +8,6 @@ namespace Unity.ClusterDisplay.Graphics
 {
     class UrpPresenter : IPresenter
     {
-        /// <summary>
-        /// A render pass whose purpose is to invoke an event at the desired stage of rendering.
-        /// </summary>
-        class InjectionPointRenderPass : ScriptableRenderPass
-        {
-            public static event Action<ScriptableRenderContext, RenderingData> ExecuteRender = delegate {};
-
-            public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)
-            {
-                ExecuteRender.Invoke(context, renderingData);
-            }
-        }
-
-        /// <summary>
-        /// A render feature whose purpose is to provide an event invoked at a given rendering stage.
-        /// Meant to abstract away the render feature mechanism and allow for simple graphics code injection.
-        /// </summary>
-        internal class InjectionPointRenderFeature : ScriptableRendererFeature
-        {
-            InjectionPointRenderPass m_Pass;
-
-            public override void Create()
-            {
-                m_Pass = new InjectionPointRenderPass
-                {
-                    renderPassEvent = RenderPassEvent.AfterRendering,
-                };
-            }
-
-            public override void AddRenderPasses(ScriptableRenderer renderer, ref RenderingData renderingData)
-            {
-                renderer.EnqueuePass(m_Pass);
-            }
-        }
-        
         const string k_CommandBufferName = "Present To Screen";
 
         Camera m_Camera;

--- a/source/com.unity.cluster-display.graphics/Runtime/ClusterRenderer.cs
+++ b/source/com.unity.cluster-display.graphics/Runtime/ClusterRenderer.cs
@@ -72,12 +72,12 @@ namespace Unity.ClusterDisplay.Graphics
         /// </summary>
         public Matrix4x4 originalProjectionMatrix => m_OriginalProjectionMatrix;
 
-#if UNITY_EDITOR
 
         // we need a clip-to-world space conversion for gizmo
         Matrix4x4 m_ViewProjectionInverse = Matrix4x4.identity;
         ClusterFrustumGizmo m_Gizmo = new ClusterFrustumGizmo();
 
+#if UNITY_EDITOR
         void OnDrawGizmos()
         {
             if (enabled)
@@ -130,11 +130,6 @@ namespace Unity.ClusterDisplay.Graphics
             m_Presenter.Enable(gameObject);
 
             PlayerLoopExtensions.RegisterUpdate<UnityEngine.PlayerLoop.PostLateUpdate, ClusterDisplayUpdate>(InjectedUpdate);
-
-            // TODO Needed?
-#if UNITY_EDITOR
-            SceneView.RepaintAll();
-#endif
         }
 
         void OnDisable()
@@ -191,10 +186,6 @@ namespace Unity.ClusterDisplay.Graphics
 
                 m_Presenter.SetSource(m_LayoutBuilder.PresentRT);
 
-// TODO is it really needed?
-#if UNITY_EDITOR
-                SceneView.RepaintAll();
-#endif
             }
         }
 

--- a/source/com.unity.cluster-display/Runtime/ClusterSync.cs
+++ b/source/com.unity.cluster-display/Runtime/ClusterSync.cs
@@ -61,9 +61,8 @@ namespace Unity.ClusterDisplay
             }
         }
 
-#if UNITY_EDITOR
         public string m_EditorCmdLine = "";
-#endif
+        
         internal ClusterNode LocalNode { get; set; }
 
         internal NetworkingStats CurrentNetworkStats => LocalNode.UdpAgent.CurrentNetworkStats;


### PR DESCRIPTION
For URP, we create an "injection point", a `ScriptableRenderFeature`. This feature needs to be serialized as part of the URP Renderer asset, so it needs to be `public`. Bizarrely, the feature being `internal` seems to work in the Editor. Also, for some reason I can't understand, the feature must live in a file with the same name (i.e. `InjectionPointRenderFeature.cs`).