### PR TITLE
Quadro Sync - Editor crash.

### DIFF
--- a/source/com.unity.cluster-display/Runtime/Plugins/x86_64/GfxPluginQuadroSync.dll.meta
+++ b/source/com.unity.cluster-display/Runtime/Plugins/x86_64/GfxPluginQuadroSync.dll.meta
@@ -16,7 +16,7 @@ PluginImporter:
     second:
       enabled: 0
       settings:
-        Exclude Editor: 1
+        Exclude Editor: 0
         Exclude Linux64: 0
         Exclude OSXUniversal: 0
         Exclude Win: 0
@@ -29,7 +29,7 @@ PluginImporter:
   - first:
       Editor: Editor
     second:
-      enabled: 0
+      enabled: 1
       settings:
         CPU: x86_64
         DefaultValueInitialized: true


### PR DESCRIPTION
### Purpose of this PR

- There was a crash in the `Editor` (`Play mode`) when `Quadro Sync` was in use. 
- The reason of the crash is because the `meta` file for the DLL was not specifying the `Editor` platform:
![image](https://user-images.githubusercontent.com/59579629/164802991-9f988361-67f5-46bf-a693-8f78285608c2.png)

- The reason of that is because at some point in the past, we removed the DLL + meta file from the package. 
- Apparently, they were added again but without the correct values in the meta file, which explains the crash.

- It was crashing because the `UnityPluginLoad` callback is not triggered, so we are trying to use null pointers.
- Because Frédérick is working on improving the errors log/display (from the native to the managed code), it might be a good idea to ask him to enforce this code (adding some security checks to avoid this error in the future and have a nice message in the console).

### Comments to reviewers

This PR is a draft, it doesn't necessarily need to be merged. It's more a FYI. 
The current `develop` is already using an `ifdef EDITOR` to avoid calling Quadro Sync in the `Editor`, which is great because it's not compatible.
