### PR TITLE
CD-169: Ensure repeater process each LastFrameData it receives.

### DIFF
--- a/source/com.unity.cluster-display/Runtime/Networking/Node/RepeaterStateReader.cs
+++ b/source/com.unity.cluster-display/Runtime/Networking/Node/RepeaterStateReader.cs
@@ -107,6 +107,11 @@ namespace Unity.ClusterDisplay
 
                     RestoreEmitterFrameData(outBuffer);
                     nodeSyncState.OnReceivedEmitterFrameData();
+
+                    // We might still have messages available, but processing them before the LastFrameData we just
+                    // received could result in skipping a LastFrameData, so stop right now, nodeSyncState now has
+                    // something to do anyway.
+                    break;
                 }
             }
         }


### PR DESCRIPTION
### Purpose of this PR

Improve robustness in timing in the repeater to better deal with a different mode in Quadro Sync frame presentation.

### Technical risk

Really low

### Testing status

- [x] Tested with the spaceship demo
- [x] Tested with the quadro sync spinning cube
- [x] Tested with both pre and post present mode
