### PR TITLE
CD-169: MissionControl install script encourage setting Quadro Sync "pre present wait"

### DIFF
--- a/source/com.unity.cluster-display/Documentation~/quadro-sync.md
+++ b/source/com.unity.cluster-display/Documentation~/quadro-sync.md
@@ -1,19 +1,21 @@
 # Quadro Sync
+
 NVIDIA's NvAPI provides the capability to synchronize the buffer swaps of a group of DirectX swap chains when using Quadro Sync II boards. This extension also provides the capability to synchronize the buffer swaps of different swaps groups, which may reside on distributed systems on a network using a swap barrier. It’s essential to coordinate the back buffer swap between nodes, so it can stay perfectly synchronized (Frame Lock + Genlock) for a large number of displays.
 
 Example **WITHOUT** Quadro Sync:
 
-![](images/without-genlock.gif)
+![Without Quadro Sync](images/without-genlock.gif)
 
 Notice that the camera cuts **are NOT synchronized** across the cluster.
 
 Example **WITH** Quadro Sync:
 
-![](images/with-genlock.gif)
+![With Quadro Sync](images/with-genlock.gif)
 
 Notice that the camera cuts **are perfectly synchronized** across the cluster.
 
 ## Requirements
+
 * Only supported on DirectX 11 or DirectX 12.
 * Requires one or more [NVIDIA Quadro GPU](https://www.nvidia.com/en-us/design-visualization/quadro/)s.
 * Requires one or more [NVIDIA Quadro Sync II](https://www.nvidia.com/en-us/design-visualization/solutions/quadro-sync/) boards.
@@ -21,65 +23,70 @@ Notice that the camera cuts **are perfectly synchronized** across the cluster.
 * Unity 2022.x+
 
 ## Recommendations
+
 * Choose a motherboard that supports [IPMI](https://en.wikipedia.org/wiki/Intelligent_Platform_Management_Interface) so you can remotely shutdown, restart and boot your nodes without needing physical access to the machines.
-* Place your emitter and repeater workstations on a dedicated network so that other network traffic does not interfer with the cluster.
+* Place your emitter and repeater workstations on a dedicated network so that other network traffic does not interfere with the cluster.
 
 ## Setup
+
 1. Verify that you've added the **ClusterDisplay** prefab to the scene located in **Cluster Display Graphics/Rutnime/Prefabs/ClusterDisplay.prefab**:
 
-    ![](images/cluster-display-prefab.png)
+    ![Cluster display prefab](images/cluster-display-prefab.png)
 
 2. Verify that the **GFXPluginQuadroSyncCallbacks** component is added and enabled:
 
-    ![](images/quadro-sync-component.png)
+    ![Quadro Sync component](images/quadro-sync-component.png)
 
 3. Verify that your Unity project has vsync set to **Every VBlank**
 
-    ![](images/vsync.png)
+    ![Unity VSync](images/vsync.png)
 
 4. Verify that your Unity project has **Fullscreen Mode** set to **Exclusive Fullscreen**
 
-    ![](images/fullscreen-exclusive.png)
+    ![Fullscreen Exclusive](images/fullscreen-exclusive.png)
 
 5. **On each node** in the cluster, verify that the display settings **Scale and Layout* option is set to 100%:
 
-    ![](images/scale-and-layout.png)
+    ![Scale and Layout to 100%](images/scale-and-layout.png)
 
 6. **On each node** in the cluster, setup the following Nvidia Control Panel settings:
    * **3D Settings > Manage 3D Settings > Global Preset** set to **Workstation App–Dynamic Streaming**
 
-    ![](images/nvidia-settings-0.png)
+    ![Workstation App–Dynamic Streaming](images/nvidia-settings-0.png)
 
    * **Vertical Sync** set to **On**. Note: must set Unity project to use V Sync
 
-    ![](images/nvidia-settings-1.png)
+    ![Nvidia VSync](images/nvidia-settings-1.png)
 
     * Set your desired resolution and frame rate.
 
-    ![](images/nvidia-settings-4.png)
+    ![Resolution and Framerate](images/nvidia-settings-4.png)
 
-7. **On the emitter (or master) node**, setup the following Nvidia Control Panel settings and make sure you set the server refresh rate to the HZ all your nodes are running at.
+7. **On the "Synchronization master" node** (often the emitter node), setup the following Nvidia Control Panel settings and make sure you set the server refresh rate to the HZ all your nodes are running at.
 
-    ![](images/nvidia-settings-2.png)
+    ![Emitter settings](images/nvidia-settings-2.png)
 
-8. **On the repeater (or slave) nodes**, setup the following Nvidia Control Panel settings.
+8. **On the "Synchronization slave" nodes** (often the repeater nodes), setup the following Nvidia Control Panel settings.
 
-    ![](images/nvidia-settings-3.png)
+    ![Repeaters settings](images/nvidia-settings-3.png)
 
 9. If your using ethernet synchronization with your Quadro Sync cards, use Nvidia's recommendation regarding daisy chaining (**DO NOT CONNECT the ethernet cables to a switch and daisy-chaining all servers from one port is not recommended**):
 
-    ![](images/connection-diagram.png)
+    ![Connection diagram](images/connection-diagram.png)
 
-10. Restart the cluster and the monitors for the repeater nodes briefly turn off, then back on after logging into the windows.
+10. Configure synchronized Quadro frame presentation to "wait before presenting next frame" as opposed to "wait for presenting of current frame to be done".  It allows the get a better frame rate by starting to work on the next frame while Quadro Sync is waiting for all nodes to be ready to present the frame.  This should normally be done automatically by [Mission Control installation](../../../MissionControl/README.md) but if you are not using it or want to do it manually, execute [Nvidia's Configure Driver Utility](https://www.nvidia.com/en-us/drivers/driver-utility/) in administrative mode and select option 11.
 
-11. Run your cluster with the **-window-mode exclusive** command argument to explicitly specify Unity to run in fullscreen exclusive mode.
-   * There is an [unexpected issue](https://forum.unity.com/threads/playersettings-are-ignored-when-building-windowed-fullscreen.257700/) where Unity will set a registry key that will override the executable in windowed/borderless if you ran the executable without explictly specifying **-window-mode exclusive**. Therefore, you will need to delete registry entries for the executable. These registry entries are located in:
-    **\HKEY_SOFTWARE_USER\SOFTWARE\\{Company Name\}\{Product Name\}**
-    <br>
-    <br>
+    ![configureDriver.exe](images/configureDriver-utility.png)
+
+11. Restart the cluster and the monitors for the repeater nodes briefly turn off, then back on after logging into the windows.
+
+12. Run your cluster with the **-window-mode exclusive** command argument to explicitly specify Unity to run in fullscreen exclusive mode.
+
+    There is an [unexpected issue](https://forum.unity.com/threads/playersettings-are-ignored-when-building-windowed-fullscreen.257700/) where Unity will set a registry key that will override the executable in windowed/borderless if you ran the executable without explicitly specifying **-window-mode exclusive**. Therefore, you will need to delete registry entries for the executable. These registry entries are located in: **\HKEY_SOFTWARE_USER\SOFTWARE\\{Company Name\}\{Product Name\}**
 
     Until we build a better way of resolving this issue, we suggest writing [PSExec](https://docs.microsoft.com/en-us/sysinternals/downloads/psexec) script that will automatically delete those registry entries for you:
-    ```
+
+    ```powershell
     # On the machine that your managing the cluster
     for($i=41; $i -le 48; $i++) { # Loop through IP address range (41-48) for 192.168.5.*
         echo "Argument: $($args[0])"
@@ -87,8 +94,9 @@ Notice that the camera cuts **are perfectly synchronized** across the cluster.
         psexec \\192.168.5.$i Powershell "C:\cluster_applications\Tools\delete-reg.ps1 $($args[0])"
         # The script were executing here is placed on each node.
     }
-    ``` 
     ```
+
+    ```powershell
     # On each node, this script exists somewhere and gets executed by the script on the machine managing the cluster.
     echo "Attempting to delete registry keys in: $($args[0])"
     reg delete "HKCU\Software\$($args[0])" /f
@@ -98,27 +106,29 @@ Notice that the camera cuts **are perfectly synchronized** across the cluster.
 
 ## Multiviewers
 
- Since both the Multiviewer and Nvidia Quadro Sync have reference input capability, you can use a tri-level sync generator from Black Magic to feed the reference signal to both the Multiviewer and Sync card.
+Since both the Multiviewer and Nvidia Quadro Sync have reference input capability, you can use a tri-level sync generator from Black Magic to feed the reference signal to both the Multiviewer and Sync card.
 
 For multiviewers, every server is output through DisplayPort and then converted to HDMI. The HDMI signal then goes to a Black Magic Design mini-converter and converted to SDI which goes directly in the Multiviewer.
 
 ## Troubleshooting
+
 You can use [Nvidia's Configure Driver Utility](https://www.nvidia.com/en-us/drivers/driver-utility/) to verify whether Quadro Sync is working as expected. Specifically **option 8.** and **option 11.**
 
-![](images/configureDriver-utility.png)
+![configureDriver.exe](images/configureDriver-utility.png)
 
 Option 8 will display a little driver debug GUI at the bottom left of any Direct X application.
 
 If it looks like this, then Quadro Sync is working correctly:
 
-![](images/option-8-working.png)
+![Quadro Sync working](images/option-8-working.png)
 
 However, if it's not working then it will display something like this:
 
-![](images/option-8-notworking.png)
+![Quadro Sync not working](images/option-8-notworking.png)
 
 We recommend that you install this on each node within the cluster and setup a [PSExec](https://docs.microsoft.com/en-us/sysinternals/downloads/psexec) script to configure the driver on each node automatically:
-```
+
+```powershell
 # On the machine that your managing the cluster
 for($i=41; $i -le 48; $i++) { # Loop through IP address range (41-48) for 192.168.5.*
     echo "Argument: $($args[0])"
@@ -127,17 +137,20 @@ for($i=41; $i -le 48; $i++) { # Loop through IP address range (41-48) for 192.16
     # The script were executing here is placed on each node.
 }
 ```
-```
+
+```powershell
 # On each node, this script exists somewhere and gets executed by the script on the machine managing the cluster.
 echo $args[0] | C:\cluster_applications\Tools\NvidiaTests\configureDriver.exe
 ```
 
-## Other Recommendations 
+## Other Recommendations
 
 ### PSExec
-We do not recommend using PSExec or PSSessions to deploy and run your cluster as we've found that PSExec and PSSessions will start executables abnorbally with extra security measures preventing Quadro Sync from working. Instead we recommend using Cluster Display's MissionControl application or writing a Python script that receives a mesage and executes the executable locally.
+
+We do not recommend using PSExec or PSSessions to deploy and run your cluster as we've found that PSExec and PSSessions will start executables abnormally with extra security measures preventing Quadro Sync from working. Instead we recommend using Cluster Display's MissionControl application or writing a Python script that receives a message and executes the executable locally.
 
 ### Operating system overlays – frame delay
+
 Whenever you have operating system managed overlays (e.g. Windows Taskbar, TeamViewer windows, Windows File Explorer) on top of your Fullscreen Unity application, this may introduce a one-frame delay causing cluster synchronization artefacts.
 
 ## Framerate drops – screen tearing
@@ -150,29 +163,16 @@ We have tested the solution with the hardware and configuration detailed below.
 
 ### Components
 
--   4 x [Supermicro SuperServer 1019GP-TT](https://www.supermicro.com/en/products/system/1U/1019/SYS-1019GP-TT.cfm)
-    with:
-
-    -   NVIDIA Quadro P6000 GPU
-
-    -   NVIDIA Quadro Sync II Kit for Pascal Quadro
-
-    -   1x Intel Xeon Gold 5122 3.6GHz Quad-Core Server CPU
-
-    -   4x 16GB DDR4 2666Mhz ECC (64GB total)
-
-    -   1x Samsung 970 Pro 512GB m.2 SSD
-
--   1x [Blackmagic Design MultiView 16](https://www.blackmagicdesign.com/ca/products/multiview/techspecs/W-MVW-01)
-
--   16x [Blackmagic Design Mini Converter SDI to HDMI 6G](https://www.blackmagicdesign.com/ca/products/miniconverters/techspecs/W-CONM-27https://www.blackmagicdesign.com/ca/products/miniconverters/techspecs/W-CONM-27)
-
--   16x [DisplayPort to HDMI cables](https://www.accellww.com/products/displayport-1-2-to-hdmi-2-0-adapter) (6ft)
-
--   16x SDI cables (6ft)
-
--   8x Cat 5 ethernet cables (6ft)
-
--   1x HDMI cable
-
--   1x Sony 55" 4K UHD HDR OLED Android Smart TV (XBR55A9G)
+* 4 x [Supermicro SuperServer 1019GP-TT](https://www.supermicro.com/en/products/system/1U/1019/SYS-1019GP-TT.cfm) with:
+  * NVIDIA Quadro P6000 GPU
+  * NVIDIA Quadro Sync II Kit for Pascal Quadro
+  * 1x Intel Xeon Gold 5122 3.6GHz Quad-Core Server CPU
+  * 4x 16GB DDR4 2666Mhz ECC (64GB total)
+  * 1x Samsung 970 Pro 512GB m.2 SSD
+* 1x [Blackmagic Design MultiView 16](https://www.blackmagicdesign.com/ca/products/multiview/techspecs/W-MVW-01)
+  * 16x [Blackmagic Design Mini Converter SDI to HDMI 6G](https://www.blackmagicdesign.com/ca/products/miniconverters/techspecs/W-CONM-27https://www.blackmagicdesign.com/ca/products/miniconverters/techspecs/W-CONM-27)
+  * 16x [DisplayPort to HDMI cables](https://www.accellww.com/products/displayport-1-2-to-hdmi-2-0-adapter) (6ft)
+  * 16x SDI cables (6ft)
+  * 8x Cat 5 ethernet cables (6ft)
+  * 1x HDMI cable
+  * 1x Sony 55" 4K UHD HDR OLED Android Smart TV (XBR55A9G)


### PR DESCRIPTION
… (instead of post that is the default)

- Talk about setting this option in quadro-sync.md
- Cosmetic improvements to quadro-sync.md detected by markdownlint

### Purpose of this PR

Change to installation script and documentation to help improve performance

### Comments to reviewers

Would have loved doing it automatically as a parameter when initializing Quadro Sync in our code but there is no api available to configure it right now, so fallback on doing it as part of the installation script and  talking about it in the documentation.

Also, installation script does not include nor download it automatically to be sure that the user can read the EULA of Nvidia.

### Technical risk

None

### Testing status

None

## Documentation & UX Writing

A new step was added to the things to be done when setting up a new node (in case mission control is not used).