### PR TITLE
CD-169: Fix configureDriver-Utility.png case in the referring .md

### DIFF
--- a/source/com.unity.cluster-display/Documentation~/quadro-sync.md
+++ b/source/com.unity.cluster-display/Documentation~/quadro-sync.md
@@ -76,7 +76,7 @@ Notice that the camera cuts **are perfectly synchronized** across the cluster.
 
 10. Configure synchronized Quadro frame presentation to "wait before presenting next frame" as opposed to "wait for presenting of current frame to be done".  It allows the get a better frame rate by starting to work on the next frame while Quadro Sync is waiting for all nodes to be ready to present the frame.  This should normally be done automatically by [Mission Control installation](../../../MissionControl/README.md) but if you are not using it or want to do it manually, execute [Nvidia's Configure Driver Utility](https://www.nvidia.com/en-us/drivers/driver-utility/) in administrative mode and select option 11.
 
-    ![configureDriver.exe](images/configureDriver-utility.png)
+    ![configureDriver.exe](images/configureDriver-Utility.png)
 
 11. Restart the cluster and the monitors for the repeater nodes briefly turn off, then back on after logging into the windows.
 
@@ -114,7 +114,7 @@ For multiviewers, every server is output through DisplayPort and then converted 
 
 You can use [Nvidia's Configure Driver Utility](https://www.nvidia.com/en-us/drivers/driver-utility/) to verify whether Quadro Sync is working as expected. Specifically **option 8.** and **option 11.**
 
-![configureDriver.exe](images/configureDriver-utility.png)
+![configureDriver.exe](images/configureDriver-Utility.png)
 
 Option 8 will display a little driver debug GUI at the bottom left of any Direct X application.
 


### PR DESCRIPTION
### Purpose of this PR

Fix image not appearing in [quadro-sync.md](https://github.com/Unity-Technologies/ClusterDisplay/blob/dev/source/com.unity.cluster-display/Documentation%7E/quadro-sync.md) when visualizing from github but working fine on a windows workstation.

### Comments to reviewers

Why or why are filename case sensitivity different under Windows than Linux...

### Technical risk

None

### Testing status

- [x] Looked at the .md on Github and it is now ok
