### PR TITLE
CD-185: Only call NvAPI_D3D1x_QueryFrameCount to confirm initialization once per second if it does not succeeds in the first frames.

### DIFF
--- a/source/com.unity.cluster-display/Runtime/Plugins/x86_64/GfxPluginQuadroSync.dll
+++ b/source/com.unity.cluster-display/Runtime/Plugins/x86_64/GfxPluginQuadroSync.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5b610ecf5870eb5b2f6d780079d2a31c238b512f69eb0bb2675a790a6bd4b662
+oid sha256:8b0a0d9c74bba383909ef900df04fae8d89aeae162986bf916bd5aef777bcc88
 size 55808

--- a/source/com.unity.cluster-display/Runtime/QuadroSync/GfxPluginQuadroSyncState.cs
+++ b/source/com.unity.cluster-display/Runtime/QuadroSync/GfxPluginQuadroSyncState.cs
@@ -12,9 +12,9 @@ namespace Unity.ClusterDisplay
         /// </summary>
         NotInitialized = 0,
         /// <summary>
-        /// QuadroSync is initialized but still waiting from feedback from emitter
+        /// QuadroSync is initialized but still waiting from feedback from Quadro-Sync master.
         /// </summary>
-        WaitingFeedbackFromEmitter = 1,
+        WaitingFeedbackFromQuadroSyncMaster = 1,
         /// <summary>
         /// QuadroSync is initialized and should be usable.
         /// </summary>
@@ -79,7 +79,7 @@ namespace Unity.ClusterDisplay
             enumValue switch
             {
                 GfxPluginQuadroSyncInitializationState.NotInitialized => "Not initialized",
-                GfxPluginQuadroSyncInitializationState.WaitingFeedbackFromEmitter => "Waiting for emitter",
+                GfxPluginQuadroSyncInitializationState.WaitingFeedbackFromQuadroSyncMaster => "Waiting for Quadro Sync master",
                 GfxPluginQuadroSyncInitializationState.Initialized => "Initialized",
                 GfxPluginQuadroSyncInitializationState.FailedUnityInterfacesNull => "Unity interfaces null",
                 GfxPluginQuadroSyncInitializationState.UnsupportedGraphicApi => "Unsupported graphic api",


### PR DESCRIPTION
Also fixed some enum / messages talking about emitter when it should in fact be the Quadro-Sync master.

### Purpose of this PR

Improve code based on Yohann's feedback.

### Comments to reviewers

None

### Technical risk

Low risk and no halo effect (except some strings that changed in the debug hud)

### Testing status

- [x] Tested with valid Quadro-Sync setup
- [x] Tested with bad Quadro-Sync setup
