### PR TITLE
Fix a couple of Mission Control bugs

### DIFF
--- a/MissionControl/Listener/Launcher.cs
+++ b/MissionControl/Listener/Launcher.cs
@@ -36,7 +36,7 @@ namespace Unity.ClusterDisplay.MissionControl
                 StartInfo =
                 {
                     FileName = "robocopy.exe",
-                    Arguments = $"{sharedProjectDir} {localProjectionDir} {k_CopyParams}"
+                    Arguments = $"\"{sharedProjectDir}\" \"{localProjectionDir}\" {k_CopyParams}"
                 }
             };
             Trace.WriteLine($"{copyProcess.StartInfo.FileName} {copyProcess.StartInfo.Arguments}");
@@ -109,7 +109,7 @@ namespace Unity.ClusterDisplay.MissionControl
             {
                 StartInfo =
                 {
-                    FileName = playerInfo.ExecutablePath,
+                    FileName = $"\"{playerInfo.ExecutablePath}\"",
                     Arguments = argString,
                     WorkingDirectory = Directory.GetParent(playerInfo.ExecutablePath)?.FullName ?? string.Empty
                 }


### PR DESCRIPTION
### Purpose of this PR

Fixes the following bugs:
[Mission Control executes UnityCrashHandler.exe bundled with the build instead of the correct exe](https://jira.unity3d.com/browse/CD-197)
[Mission Control does not respect spaces in paths management](https://jira.unity3d.com/browse/CD-195)

### Comments to reviewers

None.

### Technical risk

Technical risk: low
Halo: none

### Testing status

- [x] Tested running `ClusterListener` from a path containing spaces
- [x] Tested running a build containing `UnityCrashHandler64.exe` and the main executable further down the alphabet (`VirtualCameraTest.exe`)
- [x] Tested with Demo project