### PR TITLE
Bugfix: Visual artefacts in outer frustum cubemap (HDRP)

### DIFF
--- a/source/com.unity.cluster-display.graphics/Runtime/Camera/CameraScopeFactory.cs
+++ b/source/com.unity.cluster-display.graphics/Runtime/Camera/CameraScopeFactory.cs
@@ -158,6 +158,7 @@ namespace Unity.ClusterDisplay.Graphics
             public void RenderToCubemap(RenderTexture target, Vector3? position = null)
             {
                 m_BaseCameraScope.PreRender(position);
+                m_AdditionalCameraData.hasPersistentHistory = !m_ForceClearHistory;
                 m_Camera.RenderToCubemap(target);
             }
 


### PR DESCRIPTION
### Purpose of this PR

Fix visual artefacts caused by temporal effects when rendering the outer frustum cubemap. The bug was that the appropriate `RenderFeature.ClearHistory` flag was not respected in `HDRPCameraScope`.