### PR TITLE
Fix shader error when building projects (CD-224)

### DIFF
--- a/source/com.unity.cluster-display.graphics/Editor/EnsureShadersIncluded.cs
+++ b/source/com.unity.cluster-display.graphics/Editor/EnsureShadersIncluded.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using UnityEngine;
+using UnityEditor;
+
+namespace Unity.ClusterDisplay.Graphics.Editor
+{
+    class EnsureShadersIncluded : AssetPostprocessor
+    {
+        static void OnPostprocessAllAssets(string[] importedAssets,
+            string[] deletedAssets,
+            string[] movedAssets,
+            string[] movedFromAssetPaths)
+        {
+            // Set the project's "Always included shaders" setting
+            foreach (var type in TypeCache.GetTypesWithAttribute<RequiresUnreferencedShaderAttribute>())
+            {
+                const BindingFlags bindingFlags = BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public;
+                var members = type.GetMembers(bindingFlags)
+                    .Where(f => f.IsDefined(typeof(AlwaysIncludeShaderAttribute), false));
+
+                foreach (var memberInfo in members)
+                {
+                    var shaderName = GetProperty<string>(memberInfo);
+                    if (Util.AddAlwaysIncludedShaderIfNeeded(shaderName))
+                    {
+                        Debug.Log($"Added {shaderName} to the list of Always Included shader.");
+                    }
+                }
+            }
+        }
+
+        static T GetProperty<T>(MemberInfo memberInfo, object obj = null) =>
+            memberInfo switch
+            {
+                FieldInfo fieldInfo => (T)fieldInfo.GetValue(obj),
+                PropertyInfo propertyInfo => (T)propertyInfo.GetValue(obj),
+                _ => throw new ArgumentOutOfRangeException(nameof(memberInfo))
+            };
+    }
+}

--- a/source/com.unity.cluster-display.graphics/Editor/EnsureShadersIncluded.cs.meta
+++ b/source/com.unity.cluster-display.graphics/Editor/EnsureShadersIncluded.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 04e00f2473e67aa49b900f568af4fe04
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/source/com.unity.cluster-display.graphics/Editor/Initializer.cs
+++ b/source/com.unity.cluster-display.graphics/Editor/Initializer.cs
@@ -12,36 +12,11 @@ namespace Unity.ClusterDisplay.Graphics.Editor
     {
         static Initializer()
         {
-            // Set the project's "Always included shaders" setting
-            foreach (var type in TypeCache.GetTypesWithAttribute<RequiresUnreferencedShaderAttribute>())
-            {
-                const BindingFlags bindingFlags = BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public;
-                var members = type.GetMembers(bindingFlags)
-                    .Where(f => f.IsDefined(typeof(AlwaysIncludeShaderAttribute), false));
-
-                foreach (var memberInfo in members)
-                {
-                    var shaderName = memberInfo.GetValue<string>();
-                    if (Util.AddAlwaysIncludedShaderIfNeeded(shaderName))
-                    {
-                        Debug.Log($"Added {shaderName} to the list of Always Included shader.");
-                    }
-                }
-            }
-
             // Sanity check.
             if (XRSettings.enabled)
             {
                 Debug.LogWarning("XR is currently enabled which is not expected when using Cluster Display.");
             }
         }
-
-        static T GetValue<T>(this MemberInfo memberInfo, object obj = null) =>
-            memberInfo switch
-            {
-                FieldInfo fieldInfo => (T)fieldInfo.GetValue(obj),
-                PropertyInfo propertyInfo => (T)propertyInfo.GetValue(obj),
-                _ => throw new ArgumentOutOfRangeException(nameof(memberInfo))
-            };
     }
 }


### PR DESCRIPTION
### Purpose of this PR

Fixed an issue where our `InitializeOnLoad` script was not able to add CD shaders to the project's "Always include shaders" list, because `Shader.Find()` does not always work during initialization. Found an alternate solution using `AssetPostprocessor`.

JIRA: https://jira.unity3d.com/browse/CD-224

### Technical risk

Risk: Low (minor changes related to builds)
Halo: None

### Testing status

- [ ] Manually tested with demo project
