### PR TITLE
2022.2 crash bug

### DIFF
--- a/source/com.unity.cluster-display/Runtime/States/NodeState.cs
+++ b/source/com.unity.cluster-display/Runtime/States/NodeState.cs
@@ -79,7 +79,7 @@ namespace Unity.ClusterDisplay
         protected static IntPtr CreateProfilingMarker(string stateName)
         {
             var handle = ProfilerUnsafeUtility.CreateMarker(stateName, ProfilerUnsafeUtility.CategoryScripts,
-                MarkerFlags.Default, 1);
+                MarkerFlags.Default | MarkerFlags.AvailabilityNonDevelopment, 1);
             ProfilerUnsafeUtility.SetMarkerMetadata(handle, 0, "Frame index", (byte)ProfilerMarkerDataType.UInt64,
                 (byte)ProfilerMarkerDataUnit.Count);
             return handle;


### PR DESCRIPTION
### Purpose of this PR

Problem: Non-development builds of cluster-enabled projects crash on initialization in 2022.2.0b15 and newer.
Cause: This [commit](https://github.cds.internal.unity3d.com/unity/unity/commit/be42a66421125ffe6e26b4021234e029c42a77d1#diff-7e89f3e493d783bee42192154041c857c0e5ad06918aa1f9a2f90e42d750fda8) in trunk caused `ProfilerUnsafeUtility.CreateMarker()` to return `IntPtr.Zero` when running a non-dev builds.
Fix: Use the `AvailabilityNonDevelopment` flag when calling `ProfilerUnsafeUtility.CreateMarker()`

Unless!! Do you think it's better to disable profiling markers in release builds?

### Comments to reviewers

### Technical risk

Risk: Low
Halo: None

### Testing status

- [ ] Manually tested with demo project