### PR TITLE
Log the screen resolution at startup

### DIFF
--- a/source/com.unity.cluster-display.graphics/Runtime/ClusterRenderer.cs
+++ b/source/com.unity.cluster-display.graphics/Runtime/ClusterRenderer.cs
@@ -142,6 +142,12 @@ namespace Unity.ClusterDisplay.Graphics
                 DontDestroyOnLoad(gameObject);
             }
 
+            if (Application.isPlaying && m_ProjectionPolicy != null)
+            {
+                ClusterDebug.Log($"Cluster Rendering is enabled with {m_ProjectionPolicy.GetType()}." +
+                    $" The current screen resolution is {Screen.width} x {Screen.height}.");
+            }
+
             m_Presenter.SetDelayed(m_DelayPresentByOneFrame);
             m_Presenter.Enable(gameObject);
             m_Presenter.Present += OnPresent;


### PR DESCRIPTION
### Purpose of this PR

Log some info about the Cluster Renderering, including the projection policy and the current game window resolution.

### Technical risk

Low: Just some logging.

### Testing status
- [x] Manually tested with demo project