### PR TITLE
TiledProjection can position windows to match physical screens

### DIFF
--- a/source/com.unity.cluster-display.graphics/Editor/Inspectors/TiledProjectionInspector.cs
+++ b/source/com.unity.cluster-display.graphics/Editor/Inspectors/TiledProjectionInspector.cs
@@ -10,9 +10,9 @@ namespace Unity.ClusterDisplay.Graphics.Editor
         SerializedProperty m_GridProp;
         SerializedProperty m_ScreenSizeProp;
         SerializedProperty m_BezelProp;
+        SerializedProperty m_PositionNonFullscreenWindowProp;
         SerializedProperty m_IsDebugProp;
         SerializedProperty m_TileIndexProp;
-        SerializedProperty m_PositionNonFullscreenWindowProp;
         SerializedProperty m_LayoutProp;
         SerializedProperty m_KeywordProp;
         SerializedProperty m_DebugViewportProp;
@@ -28,9 +28,9 @@ namespace Unity.ClusterDisplay.Graphics.Editor
             m_GridProp = serializedObject.FindProperty("m_Settings.GridSize");
             m_ScreenSizeProp = serializedObject.FindProperty("m_Settings.PhysicalScreenSize");
             m_BezelProp = serializedObject.FindProperty("m_Settings.Bezel");
+            m_PositionNonFullscreenWindowProp = serializedObject.FindProperty("m_Settings.PositionNonFullscreenWindow");
             m_IsDebugProp = serializedObject.FindProperty("m_IsDebug");
             m_TileIndexProp = serializedObject.FindProperty("m_NodeIndexOverride");
-            m_PositionNonFullscreenWindowProp = serializedObject.FindProperty("m_PositionNonFullscreenWindow");
             m_LayoutProp = serializedObject.FindProperty("m_DebugSettings.LayoutMode");
             m_KeywordProp = serializedObject.FindProperty("m_DebugSettings.EnableKeyword");
             m_PresentClearColorProp = serializedObject.FindProperty("m_DebugSettings.PresentClearColor");
@@ -51,8 +51,8 @@ namespace Unity.ClusterDisplay.Graphics.Editor
                 EditorGUILayout.PropertyField(m_GridProp, Labels.GetGUIContent(Labels.Field.GridSize));
                 EditorGUILayout.PropertyField(m_ScreenSizeProp, Labels.GetGUIContent(Labels.Field.PhysicalScreenSize));
                 EditorGUILayout.PropertyField(m_BezelProp, Labels.GetGUIContent(Labels.Field.Bezel));
-                EditorGUILayout.PropertyField(m_TileIndexProp);
                 EditorGUILayout.PropertyField(m_PositionNonFullscreenWindowProp, Labels.GetGUIContent(Labels.Field.PositionNonFullscreenWindows));
+                EditorGUILayout.PropertyField(m_TileIndexProp);
                 EditorGUILayout.PropertyField(m_IsDebugProp, Labels.GetGUIContent(Labels.Field.Debug));
                 if (m_IsDebugProp.boolValue)
                 {

--- a/source/com.unity.cluster-display.graphics/Editor/Labels.cs
+++ b/source/com.unity.cluster-display.graphics/Editor/Labels.cs
@@ -30,7 +30,7 @@ namespace Unity.ClusterDisplay.Graphics
             ForceClearHistory
         }
 
-        static string GetName(Field field)
+        public static string GetName(Field field)
         {
             switch (field)
             {
@@ -58,7 +58,7 @@ namespace Unity.ClusterDisplay.Graphics
             return string.Empty;
         }
 
-        static string GetTooltip(Field field)
+        public static string GetTooltip(Field field)
         {
             switch (field)
             {

--- a/source/com.unity.cluster-display.graphics/Editor/MissionControlPolicyPreProcessor.cs
+++ b/source/com.unity.cluster-display.graphics/Editor/MissionControlPolicyPreProcessor.cs
@@ -89,6 +89,14 @@ namespace Unity.ClusterDisplay.Graphics
                 "Physical height of a display (not to be confused with screen size in pixels).");
             AddVector2IntParameter(ret.GlobalParameters, "Bezel", TiledProjection.BezelParameterId,
                 "Physical width of display bezels.", "Physical height of display bezels.");
+            ret.GlobalParameters.Add(new()
+            {
+                Name = Labels.GetName(Labels.Field.PositionNonFullscreenWindows),
+                Id = TiledProjection.PositionWindowsParameterId,
+                Description = Labels.GetTooltip(Labels.Field.PositionNonFullscreenWindows),
+                Type = LaunchParameterType.Boolean,
+                DefaultValue = false
+            });
             return ret;
         }
 

--- a/source/com.unity.cluster-display.graphics/Runtime/ClusterRendererMissionControlUtils.cs
+++ b/source/com.unity.cluster-display.graphics/Runtime/ClusterRendererMissionControlUtils.cs
@@ -78,6 +78,12 @@ namespace Unity.ClusterDisplay.Graphics
             {
                 baseSettings.PhysicalScreenSize = physicalSizeValue;
             }
+
+            var positionWindows = launchData?.Value<bool?>(TiledProjection.PositionWindowsParameterId);
+            if (positionWindows.HasValue)
+            {
+                baseSettings.PositionNonFullscreenWindow = positionWindows.Value;
+            }
         }
 
         static bool TryGetVector2Int(JObject rawLaunchData, string parameterName, out Vector2Int value)

--- a/source/com.unity.cluster-display.graphics/Runtime/Projections/TiledProjection.cs
+++ b/source/com.unity.cluster-display.graphics/Runtime/Projections/TiledProjection.cs
@@ -28,6 +28,12 @@ namespace Unity.ClusterDisplay.Graphics
         /// Physical size of the screen in mm. Used to compute bezel.
         /// </summary>
         public Vector2 PhysicalScreenSize;
+
+        /// <summary>
+        /// Do we position the windows on the screen according to the physical screen layouts.
+        /// </summary>
+        /// <remarks>Mostly useful when debugging and running multiple nodes on the same computer.</remarks>
+        public bool PositionNonFullscreenWindow;
     }
 
     /// <summary>
@@ -91,9 +97,6 @@ namespace Unity.ClusterDisplay.Graphics
 
         [SerializeField]
         TiledProjectionDebugSettings m_DebugSettings = new() { ViewportSubsection = new Rect(0, 0, 0.5f, 0.5f) };
-
-        [SerializeField]
-        bool m_PositionNonFullscreenWindow;
 
         readonly SlicedFrustumGizmo m_Gizmo = new SlicedFrustumGizmo();
         readonly List<BlitCommand> m_BlitCommands = new List<BlitCommand>();
@@ -267,6 +270,7 @@ namespace Unity.ClusterDisplay.Graphics
         public const string GridSizeParameterId = "GridSize";
         public const string BezelParameterId = "Bezel";
         public const string PhysicalScreenSizeParameterId = "PhysicalScreenSize";
+        public const string PositionWindowsParameterId = "PositionWindows";
 
         void RenderStitcher(
             IReadOnlyList<RenderTexture> targets,
@@ -347,7 +351,7 @@ namespace Unity.ClusterDisplay.Graphics
 #if UNITY_EDITOR
             return false;
 #else
-            return m_PositionNonFullscreenWindow && !Screen.fullScreen;
+            return Settings.PositionNonFullscreenWindow && !Screen.fullScreen;
 #endif
         }
 

--- a/source/com.unity.cluster-display/Runtime/MissionControl/MissionControlSettings.cs
+++ b/source/com.unity.cluster-display/Runtime/MissionControl/MissionControlSettings.cs
@@ -63,7 +63,7 @@ namespace Unity.ClusterDisplay.MissionControl
             /// <summary>
             /// Does the contain contain anything.
             /// </summary>
-            public bool Any => GlobalParameters.Any() && LaunchComplexParameters.Any() && LaunchPadParameters.Any();
+            public bool Any => GlobalParameters.Any() || LaunchComplexParameters.Any() || LaunchPadParameters.Any();
         }
     }
 }


### PR DESCRIPTION
### Purpose of this PR

Add an option to TileProjectionPolicy
![image](https://user-images.githubusercontent.com/103442493/234269525-697cc13d-8144-4f76-845c-7453da028dca.png)

that will position windows (so does nothing when in full screen) to represent the layout of the physical screens:
![image](https://user-images.githubusercontent.com/103442493/234270496-88fcaca9-e8d6-464b-9338-74b5c9325179.png)

### Comments to reviewers

None

### Technical risk

None

### Testing status

- [x] Tested manually
- [x] Tested that backup nodes windows are not positioned until they are assigned their real role.
- [x] All automated tests pass